### PR TITLE
upgrade Bundler to address failed deploy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,4 +176,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Summary:
Deploying to Heroku failed with the message: "Could not detect rake
tasks... Activating bundler (2.0.1) failed". Running `bundle update
--bundler`, which updated the Bundler version to 2.0.2, resolved the
issue.

<img width="1499" alt="Screen Shot 2019-07-05 at 3 11 44 PM" src="https://user-images.githubusercontent.com/4016985/60741400-386a0280-9f37-11e9-924d-74de1a1b8090.png">
